### PR TITLE
FIX3P-3 Documentation Site Visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postbuild": "node postbuild.js",
     "types": "tsc -d --emitDeclarationOnly --allowJs false --outDir types",
     "docs": "typedoc --out docs --excludePrivate --excludeProtected --excludeNotExported",
+    "postdocs": "touch docs/.nojekyll",
     "postversion": "git push --follow-tags"
   },
   "keywords": [


### PR DESCRIPTION
Fixes the visibility of some pages on the documentation website.  The issue was that github was treating it as a jekyll site - where pages with underscores get ignored.  Adds a postdocs script to create a .nojekyll file.  When this file is present, github will not treat it as a jekyll site. 