### PR TITLE
FIX3P-11 Default Mask Loading

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,4 +1,3 @@
-
 import Manifest from "./manifest";
 import Mask from "./mask/index";
 import X3P from "./index";
@@ -10,6 +9,7 @@ import { EventEmitter } from "events";
 export interface LoaderOptions {
     file: any;
     name?: string;
+    defaultMask?: string;
     missingFactorThreshold?: number;
 }
 
@@ -56,6 +56,11 @@ export default class Loader extends EventEmitter {
     private root?: string = "";
 
     /**
+     * Default mask to use for the manifest
+     */
+    private defaultMask?: string;
+
+    /**
      * Constructs a new X3P Loader
      * 
      * @param options options to use for loading the X3P file
@@ -64,6 +69,7 @@ export default class Loader extends EventEmitter {
         super();
         this.options = options;
         this.name = options.file.name || options.name || "file.x3p";
+        this.defaultMask = options.defaultMask || this.defaultMask;
         this.load();
     }
 
@@ -140,7 +146,7 @@ export default class Loader extends EventEmitter {
             this.root = file.name.replace("main.xml", "");
         }
 
-        this.manifest = new Manifest(await file.async("text"));
+        this.manifest = new Manifest(await file.async("text"), this.defaultMask);
         let pointBuffer = await this.getPointBuffer();
         let mask = await this.getMask() as Mask;
         let missingFactorThreshold = this.options.missingFactorThreshold || DEFAULT_MISSING_FACTOR_THRESHOLD;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,5 +1,5 @@
 import Tree from "./tree.xml";
-import DefaultMask from "./mask.xml";
+import DEFAULT_MASK from "./mask.xml";
 import md5 from "blueimp-md5";
 
 declare var window: any;
@@ -49,7 +49,7 @@ export default class Manifest {
     /**
      * The mask template to use
      */
-    private static [$defaultMask]: string = DefaultMask;
+    private defaultMask: string;
 
     /**
      * Dom tree created from the user-provided XML
@@ -90,8 +90,10 @@ export default class Manifest {
      * Constructs a new Manifest object
      * 
      * @param source the source XML to parse
+     * @param defaultMask mask to use if the user doesn't supply one
      */
-    constructor(source: string) {
+    constructor(source: string, userSpecifiedDefaultMask?: string) {
+        this.defaultMask = userSpecifiedDefaultMask || DEFAULT_MASK;
         this.tree = this.prepareTree();
         this.data = Parser.parseFromString(source, "text/xml");
         
@@ -100,20 +102,6 @@ export default class Manifest {
 
         // @ts-ignore - don't need to keep this tree in memory
         this.data = null;
-    }
-    
-    /**
-     * Gets the default mask template
-     */
-    public static get defaultMask() {
-        return this[$defaultMask];
-    }
-
-    /**
-     * Sets the default mask template
-     */
-    public static set defaultMask(mask) {
-        this[$defaultMask] = mask.trim() === "" ? DefaultMask : mask;
     }
 
     /**
@@ -231,7 +219,12 @@ export default class Manifest {
      * Prepares the source tree XML with the mask template
      */
     private prepareTree() {
-        let src = Tree.replace("<Mask/>", Manifest.defaultMask);
+        let src = Tree;
+
+        if(typeof this.defaultMask !== "undefined") {
+            src = src.replace("<Mask/>", this.defaultMask);
+        }
+
         return Parser.parseFromString(src, "text/xml");
     }
 

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -176,46 +176,4 @@ describe("Manifest", () => {
             expect(manifest.toString()).toBe(expects);
         });
     });
-
-    describe("get defaultMask", () => {
-        it("Should initially return the contents of mask.xml", () => {
-            expect(Manifest.defaultMask).toBe(DEFAULT_MASK);
-        });
-    });
-
-    describe("set defaultMask", () => {
-        it("Should update the defaultMask", () => {
-            let updated = `<Mask><Background>#000000</Background></Mask>`;
-            Manifest.defaultMask = updated;
-            expect(Manifest.defaultMask).toBe(updated);
-        });
-
-        it("Updated default masks should be present in new Manifest objects", () => {
-            let updated = `<Mask><Background>#000000</Background></Mask>`;
-            Manifest.defaultMask = updated;
-
-            let source = `<root></root>`;
-            let manifest = new Manifest(source);
-            let background = manifest.get("Record3 Mask Background");
-            expect(background).toBe("#000000");
-        });
-
-        it("Setting it to an empty value should reset the defaultMask to its original state", () => {
-            let updated = `<Mask><Background>#000000</Background></Mask>`;
-            Manifest.defaultMask = updated;
-            expect(Manifest.defaultMask).toBe(updated);
-
-            Manifest.defaultMask = "";
-            expect(Manifest.defaultMask).toBe(DEFAULT_MASK);
-        });
-
-        it("Setting it to a string with only spaces should reset the defaultMask to its original state", () => {
-            let updated = `<Mask><Background>#000000</Background></Mask>`;
-            Manifest.defaultMask = updated;
-            expect(Manifest.defaultMask).toBe(updated);
-
-            Manifest.defaultMask = "      ";
-            expect(Manifest.defaultMask).toBe(DEFAULT_MASK);
-        });
-    });
 });


### PR DESCRIPTION
Adds a default mask property to the LoaderOptions struct and removes the global/static manifest setter to make setting options more uniform/less confusing