### PR TITLE
v0.10.1

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,7 +1,7 @@
 import Tree from "./tree.xml";
 import DEFAULT_MASK from "./mask.xml";
 import md5 from "blueimp-md5";
-import Mask from "./mask";
+import Mask from "./mask/index";
 
 declare var window: any;
 


### PR DESCRIPTION
- Fixes an ambiguous reference to ./mask in src/manifest.ts.  
When parcelized, it is reading mask.xml instead of mask/index.ts