### PR TITLE
FIX3P-22 De-Duplicate Annotation Keys

### DIFF
--- a/src/mask/annotation-handler.ts
+++ b/src/mask/annotation-handler.ts
@@ -2,9 +2,19 @@
 
 function ownKeys(target: Element): string[] {
     const annotations = Array.from(target.querySelectorAll("Annotations Annotation"));
-    return annotations
-        .map((annotation: Element) => annotation.getAttribute("color"))
-        .filter((color) => color != null) as string[];
+    const colors: { [color: string]: boolean } = {};
+    
+    for(const annotation of annotations) {
+        const color = annotation.getAttribute("color");
+
+        if(color == null) {
+            continue;
+        }
+
+        colors[color] = true;
+    }
+
+    return Object.keys(colors);
 }
 
 function getOwnPropertyDescriptor(target: Element, prop: string) {

--- a/tests/mask.test.ts
+++ b/tests/mask.test.ts
@@ -95,6 +95,25 @@ describe("Mask", () => {
             let mask = new Mask({ manifest });
             expect(Object.keys(mask.annotations)).toEqual([ "red", "blue" ]);
         });
+
+        it("Should de-duplicate the colors", () => {
+            let manifest = new Manifest(`
+                <root>
+                    <Record3>
+                        <Mask>
+                            <Annotations>
+                                <Annotation color="red">Example Label</Annotation>
+                                <Annotation color="blue">Example Label</Annotation>
+                                <Annotation color="red">Example Label</Annotation>
+                            </Annotations>
+                        </Mask>
+                    </Record3>
+                </root>
+            `);
+
+            let mask = new Mask({ manifest });
+            expect(Object.keys(mask.annotations)).toEqual([ "red", "blue" ]);
+        });
     });
 
     describe("set annotations", () => {


### PR DESCRIPTION
De-Duplicate annotation keys in the ownKeys proxy handler.   This update is related to talenfisher/fix3p#55.  If multiple annotations exist with the same color, opening them in fix3p will cause an error before the color worker has a chance to cleanup duplicates